### PR TITLE
nft-load-example-ruleset.py: fix libnftables JSON syntax

### DIFF
--- a/nft-load-example-ruleset.py
+++ b/nft-load-example-ruleset.py
@@ -42,7 +42,7 @@ NFTABLES_JSON = """
     { "add": { "chain": {
         "family": "inet",
         "table": "mytable",
-        "chain": "mychain"
+        "name": "mychain"
     }}},
     { "add": { "rule": {
         "family": "inet",
@@ -50,6 +50,7 @@ NFTABLES_JSON = """
         "chain": "mychain",
         "expr": [
             { "match": {
+                "op": "==",
                 "left": { "payload": {
                     "protocol": "tcp",
                     "field": "dport"


### PR DESCRIPTION
The man page example was invalid, cf. the following nftables commit:

 commit ad5669a40381
 Author: Štěpán Němec <snemec@redhat.com>
 Date:   Mon Oct 11 13:59:04 2021 +0200

     doc: libnftables-json: make the example valid libnftables JSON input

Signed-off-by: Štěpán Němec <stepnem@gmail.com>